### PR TITLE
ドラフトPRでは実行しないGitHubActionを追加

### DIFF
--- a/.github/workflows/test-only-pr.yml
+++ b/.github/workflows/test-only-pr.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: echo only PR
-        run: echo "This is Opened PR!!"
+        run: echo "*** This is Opened PR!! ***"

--- a/.github/workflows/test-only-pr.yml
+++ b/.github/workflows/test-only-pr.yml
@@ -8,7 +8,7 @@ jobs:
     # https://docs.github.com/ja/actions/learn-github-actions/expressions#literals
     # https://zenn.dev/nekomaho/articles/1eef80533785c9
     # PRがドラフト以外の場合だけ、以下の処理を行う
-    if: github.event.pull_request.draft == false
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: echo only PR

--- a/.github/workflows/test-only-pr.yml
+++ b/.github/workflows/test-only-pr.yml
@@ -1,0 +1,15 @@
+name: test-only-pr
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    # https://docs.github.com/ja/actions/learn-github-actions/expressions#literals
+    # https://zenn.dev/nekomaho/articles/1eef80533785c9
+    # PRがドラフト以外の場合だけ、以下の処理を行う
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: echo only PR
+        run: echo "This is Opened PR!!"

--- a/.github/workflows/test-only-pr.yml
+++ b/.github/workflows/test-only-pr.yml
@@ -2,6 +2,8 @@ name: test-only-pr
 
 on:
   pull_request:
+    # https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#pull_request
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   test:


### PR DESCRIPTION
「正式な」PRの時だけ `echo` を行うワークフローをテスト的に実装した。

正式なPR
![image](https://user-images.githubusercontent.com/16306537/202908484-2d3a15d4-4a8f-4066-b404-06c89f387b42.png)

ドラフトPR（スキップされてる）
![image](https://user-images.githubusercontent.com/16306537/202908572-4ff43d0e-4e3d-47c3-aee5-9183f086b7d0.png)

ドラフト -> Ready for Reviewでも処理されるよ
![image](https://user-images.githubusercontent.com/16306537/202908943-a63b2f73-656d-4c25-8a95-976977b50812.png)
